### PR TITLE
fix None Openai key to default to env

### DIFF
--- a/indy_dev_tools/modules/idt_config.py
+++ b/indy_dev_tools/modules/idt_config.py
@@ -49,6 +49,8 @@ def load_config() -> IdtConfig:
                 config_data = yaml.safe_load(file)
                 if config_data:
                     config_in_memory = IdtConfig.model_validate(config_data)
+                    if config_in_memory.yt.openai_api_key is None:
+                        raise ValueError("OpenAI API key is not set.")
                     generate_directories(config_in_memory.yt)
                     return config_in_memory
                 else:


### PR DESCRIPTION
# Issue
When attempting to start the application if the yaml file exists but the openai key is not defined, there is no logic to allow the system to default to the environment openai key.  This doesn't allow for the application to boot unless the user goes to the yaml file and edits it directly.


# Issue Commands and Outputs
`python -m indy_dev_tools.main yt config`

`Error loading configuration: OpenAI API key is not set.`

`Configuration loaded: yt=IdtYoutube(openai_api_key=None, operating_dir='/Users/Ford/Desktop', config_file_path='/Users/Ford/Library/Application Support/indy_dev_tools/config.yml')`


# Current Fix
After validation, check if Open Ai Key is None, if so, throw error thus resulting in the error code to run and use the default value

# Possible Better Solution
Adjusting the IdtYoutube model to have a non optional openai_api_key, not sure though how this would effect the rest of the application.
